### PR TITLE
Disable Pulseaudio's idle exit

### DIFF
--- a/configs/pulseaudio/daemon.conf
+++ b/configs/pulseaudio/daemon.conf
@@ -35,7 +35,7 @@
 ; realtime-scheduling = yes
 ; realtime-priority = 5
 
-exit-idle-time = 180
+exit-idle-time = -1
 ; scache-idle-time = 20
 
 ; dl-search-path = (depends on architecture)


### PR DESCRIPTION
This way playing a game, exiting, then reconnecting some time later won't fail due to missing pulse.