### PR TITLE
Add a script to automatically install the Nvidia Xorg driver if possible

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !configs/
 !startup.sh
 !startup-gpu.sh
+!ensure-nvidia-xorg-driver.sh

--- a/README.md
+++ b/README.md
@@ -47,19 +47,7 @@ This should make the window take the full screen, giving you a nice result like:
 
 Pull the `:gpu` tag in order to try out hardware acceleration using the GPU.
 
-```console
-docker run -it --rm \
-    --name retroarch \
-    -p 47984-47990:47984-47990/tcp \
-    -p 48010:48010 \
-    -p 48010:48010/udp \
-    -p 47998-48000:47998-48000/udp \
-    --volume ~/retroarch:/retroarch/ \
-    --privileged \ # needed all devices for now
-    --env RESOLUTION=1920x1080x24 \
-    --env LOG_LEVEL=INFO \
-    abeltramo/retroarch:gpu # make sure to pick :gpu tag
-```
+### Nvidia GPUs with `nouveau` drivers
 
 Make sure that the host doesn't use proprietary drivers but it's using the open source `nouveau` drivers.
 ```
@@ -76,6 +64,84 @@ drwxr-xr-x 17 root root       3100 Jun 20 10:33 ..
 drwxr-xr-x  2 root root         80 Jun 20 09:47 by-path
 crw-rw----  1 root video  226,   0 Jun 20 09:47 card0
 crw-rw----  1 root render 226, 128 Jun 20 09:47 renderD128
+```
+
+```console
+docker run -it --rm \
+    --name retroarch \
+    -p 47984-47990:47984-47990/tcp \
+    -p 48010:48010 \
+    -p 48010:48010/udp \
+    -p 47998-48000:47998-48000/udp \
+    --volume ~/retroarch:/retroarch/ \
+    --privileged \ # needed all devices for now
+    --env RESOLUTION=1920x1080x24 \
+    --env LOG_LEVEL=INFO \
+    abeltramo/retroarch:gpu # make sure to pick :gpu tag
+```
+### Nvidia GPUs with proprietary drivers
+
+You can see if your host is using the proprietary driver using `lshw`:
+```console
+$ lshw -class video | grep -i driver
+       configuration: driver=nvidia latency=0
+```
+
+In order to make use of your GPU inside docker containers, you'll need to set up the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker).
+
+Once that's done, you can run the container:
+```console
+docker run --runtime=nvidia -it --rm \
+    --name retroarch \
+    -p 47984-47990:47984-47990/tcp \
+    -p 48010:48010 \
+    -p 48010:48010/udp \
+    -p 47998-48000:47998-48000/udp \
+    --volume ~/retroarch:/retroarch/ \
+    --privileged \ # needed all devices for now
+    --env RESOLUTION=1920x1080x24 \
+    --env LOG_LEVEL=INFO \
+    --env NVIDIA_VISIBLE_DEVICES=GPU-[uuid] \
+    --env NVIDIA_DRIVER_CAPABILITIES=utility,graphics,video,display \
+    abeltramo/retroarch:gpu
+```
+
+To get the correct UUID for your GPU, use the `nvidia-container-cli` command:
+```console
+$ sudo nvidia-container-cli --load-kmods info
+NVRM version:   465.27
+CUDA version:   11.3
+
+Device Index:   0
+Device Minor:   0
+Model:          NVIDIA GeForce [model]
+Brand:          GeForce
+GPU UUID:       GPU-[uuid]
+Bus Location:   00000000:0a:00.0
+Architecture:   7.5
+```
+
+##### Xorg drivers
+
+Because Nvidia does not officially support running Xorg inside a container with their Container Toolkit, it does not automatically provide you with the `nvidia_drv.so` driver module that Xorg requires.  The preferred method for making it available inside the container is to map it in from the host as a bind volume.  This ensures it is always the correct version. Find the module on your host, then add a volume mapping like this to your `docker run` command:
+```console
+--volume /path/to/nvidia_drv.so:/nvidia/xorg/nvidia_drv.so:ro
+```
+
+Some common locations for `nvidia_drv.so` include:
+ * /usr/lib64/xorg/modules/drivers/nvidia_drv.so (Unraid)
+ * /usr/lib/x86_64-linux-gnu/nvidia/xorg/nvidia_drv.so (Ubuntu 20.04)
+
+If you don't want to do this, or if you can't find the driver on your host for some reason, the container will attempt to install the correct version for you automatically.  However, there are some drawbacks: first, it can take a long time, and second, there is no guarantee that it will be able to find a version that exactly matches the driver version on your host.
+
+If the automatic option is working for you and you want to speed up future launches of the container, you can provide a persistent volume for it to cache some of the setup work, using a mapping like this:
+```console
+--volume ~/dr-cache:/var/cache/dummy
+```
+
+If for some reason you want to skip the entire process and just assume the driver is already installed, you can do that too:
+```console
+--env SKIP_NVIDIA_DRIVER_CHECK=1
 ```
 
 ## Troubleshooting

--- a/configs/xorg-nvidia.conf
+++ b/configs/xorg-nvidia.conf
@@ -1,0 +1,11 @@
+# Look for the nvidia_drv.so module in a custom location, to make it easier for
+# people to map the host's driver version as a bind volume. If there is no
+# driver in that location, this is a no-op.
+Section "OutputClass"
+    Identifier "nvidia"
+    MatchDriver "nvidia-drm"
+    Driver "nvidia"
+    Option "AllowEmptyInitialConfiguration"
+    ModulePath "/nvidia/xorg"
+EndSection
+

--- a/ensure-nvidia-xorg-driver.sh
+++ b/ensure-nvidia-xorg-driver.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+DUMMY_PACKAGE_CACHE=/var/cache/dummy
+
 NVIDIA_DRIVER_MOUNT_LOCATION=/nvidia/xorg
 NVIDIA_PACKAGE_LOCATION=/usr/lib/x86_64-linux-gnu/nvidia/xorg
 
 # If the user has requested to skip the check, do so
-if [ "${NVIDIA_SKIP_DRIVER_CHECK:-0}" = "1" ]; then
+if [ "${SKIP_NVIDIA_DRIVER_CHECK:-0}" = "1" ]; then
     exit
 fi
 
@@ -51,48 +53,74 @@ if [ -z "$PACKAGE_APT_VERSION" ]; then
     fail "Failed to locate a package with the same driver version ($HOST_DRIVER_VERSION)"
 fi
 
-cd /tmp
+mkdir -p $DUMMY_PACKAGE_CACHE
+cd $DUMMY_PACKAGE_CACHE
 
 DUMMY_NAME=nvidia-dummy
-DUMMY_FILE=${DUMMY_NAME}_1.0_all.deb
+DUMMY_VERSION=${HOST_DRIVER_VERSION}
+DUMMY_FILE=${DUMMY_NAME}_${DUMMY_VERSION}_all.deb
 
 __ticks=0
 function tick() {
     __ticks=$((__ticks+1))
     echo -ne "\rWorking: " >&3
     printf '.%.0s' $(seq 1 $__ticks) >&3
-    if [ ${1:-} = "last" ]; then
+    if [ "${1:-}" = "last" ]; then
         echo -ne "\n" >&3
     fi
 }
 
 function build_dummy() {
-    echo "Telling APT about the host driver (this may take a while)..."
+    echo "Telling APT about the host driver (this may take a while)"
     (
-        set -e # fail early
-        tick
+        # exit the subshell early if any of the commands fail.
+        set -e; tick
+
+        # Create a `control` file for use by equivs to build the dummy package.
+        # We do this manually instead of using equivs-build because it's easier
+        # than editing in the custom values later.
         cat << CONTROL >${DUMMY_NAME}.control
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Package: ${DUMMY_NAME}
+Version: ${DUMMY_VERSION}
 Provides: libnvidia-cfg1-${HOST_DRIVER_MAJOR_VERSION} (= ${PACKAGE_APT_VERSION})
 Description: Placeholder for nvidia-docker provided libs
  Since nvidia-docker provides most of the required drivers, this package tells APT about the current version for dependency purposes.
 CONTROL
         tick
+
+        # Install equivs
+        apt-get update; tick
         apt-get -qqy --no-install-recommends install equivs; tick
+
+        # Build the dummy package
         equivs-build ${DUMMY_NAME}.control; tick
+        rm ${DUMMY_NAME}.control; tick
+
+        # Clean up all the extra junk we don't need anymore.
         apt-get -qqy remove equivs; tick
-        apt-get -qqy remove --autoremove; tick
-        dpkg -i ${DUMMY_FILE}; tick
-        rm ${DUMMY_NAME}.control ${DUMMY_FILE}; tick last
+        apt-get -qqy remove --autoremove; tick last
     ) 3>&1 &>/dev/null
 }
 
-if build_dummy; then
-    echo "Installing Nvidia X driver ($PACKAGE_APT_VERSION)..."
-    apt-get install -qqy --no-install-recommends "$PACKAGE_NAME=$PACKAGE_APT_VERSION" >/dev/null
+# If there's already a dummy package with the appropriate version, just use it
+# instead of rebuilding.
+if [ -f "$DUMMY_PACKAGE_CACHE/${DUMMY_FILE}" ]; then
+    echo "Telling APT about the host driver (cached)"
+else
+    if ! build_dummy; then
+        fail "Could not generate dependencies"
+    fi
+fi
+
+if dpkg -i ${DUMMY_FILE} &>/dev/null; then
+    echo -n "Installing Nvidia X driver ($PACKAGE_APT_VERSION)..."
+    apt-get install -qqy --no-install-recommends "$PACKAGE_NAME=$PACKAGE_APT_VERSION" &>/dev/null
+    echo "done."
 else
     fail "The Nvidia X driver could not be automatically installed."
 fi
+
+

--- a/ensure-nvidia-xorg-driver.sh
+++ b/ensure-nvidia-xorg-driver.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+NVIDIA_DRIVER_MOUNT_LOCATION=/nvidia/xorg
+NVIDIA_PACKAGE_LOCATION=/usr/lib/x86_64-linux-gnu/nvidia/xorg
+
+# If the user has requested to skip the check, do so
+if [ "${NVIDIA_SKIP_DRIVER_CHECK:-0}" = "1" ]; then
+    exit
+fi
+
+function fail() {
+    (
+        if [ ! -z "${1:-}" ]; then
+            echo "$1"
+        fi
+        echo "Xorg may fail to start; try mounting drivers from your host as a volume."
+    ) >&2
+    exit 1
+}
+
+# If there's an nvidia_drv.so in the mount location, or in the location where
+# the xserver-xorg-video-nvidia package installs to, assume it's the right one
+for d in $NVIDIA_DRIVER_MOUNT_LOCATION $NVIDIA_PACKAGE_LOCATION; do
+    if [ -f $d/nvidia_drv.so ]; then
+        echo "Found an existing nvidia_drv.so"
+        exit
+    fi
+done
+
+# Otherwise, try to download the correct package.
+# Inspired by https://github.com/andrewmackrodt/dockerfiles/blob/master/ubuntu-x11/entrypoint.d/root/start/15-nvidia-driver,
+# but only installs the Xorg driver
+HOST_DRIVER_VERSION=$(cat /proc/driver/nvidia/version | sed -nE 's/.*Module[ \t]+([0-9]+(\.[0-9]+)?).*/\1/p')
+HOST_DRIVER_MAJOR_VERSION=$(echo "$HOST_DRIVER_VERSION" | sed -E 's/\..+//')
+
+PACKAGE_NAME="xserver-xorg-video-nvidia-$HOST_DRIVER_MAJOR_VERSION"
+
+MAJOR_PACKAGE_APT_VERSIONS=$( \
+    apt-cache madison "$PACKAGE_NAME" \
+        | awk '{ print $3 }' \
+        | sort -rV
+    )
+
+PACKAGE_APT_VERSION=$( \
+    echo "$MAJOR_PACKAGE_APT_VERSIONS" \
+        | grep "$HOST_DRIVER_VERSION" \
+        | head -n1 \
+    )
+
+if [ -z "$PACKAGE_APT_VERSION" ]; then
+    fail "Failed to locate a package with the same driver version ($HOST_DRIVER_VERSION)"
+fi
+
+cd /tmp
+
+DUMMY_NAME=nvidia-dummy
+DUMMY_FILE=${DUMMY_NAME}_1.0_all.deb
+
+__ticks=0
+function tick() {
+    __ticks=$((__ticks+1))
+    echo -ne "\rWorking: " >&3
+    printf '.%.0s' $(seq 1 $__ticks) >&3
+    if [ ${1:-} = "last" ]; then
+        echo -ne "\n" >&3
+    fi
+}
+
+function build_dummy() {
+    echo "Telling APT about the host driver (this may take a while)..."
+    (
+        set -e # fail early
+        tick
+        cat << CONTROL >${DUMMY_NAME}.control
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+Package: ${DUMMY_NAME}
+Provides: libnvidia-cfg1-${HOST_DRIVER_MAJOR_VERSION} (= ${PACKAGE_APT_VERSION})
+Description: Placeholder for nvidia-docker provided libs
+ Since nvidia-docker provides most of the required drivers, this package tells APT about the current version for dependency purposes.
+CONTROL
+        tick
+        apt-get -qqy --no-install-recommends install equivs; tick
+        equivs-build ${DUMMY_NAME}.control; tick
+        apt-get -qqy remove equivs; tick
+        apt-get -qqy remove --autoremove; tick
+        dpkg -i ${DUMMY_FILE}; tick
+        rm ${DUMMY_NAME}.control ${DUMMY_FILE}; tick last
+    ) 3>&1 &>/dev/null
+}
+
+if build_dummy; then
+    echo "Installing Nvidia X driver ($PACKAGE_APT_VERSION)..."
+    apt-get install -qqy --no-install-recommends "$PACKAGE_NAME=$PACKAGE_APT_VERSION" >/dev/null
+else
+    fail "The Nvidia X driver could not be automatically installed."
+fi

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -77,7 +77,9 @@ COPY --from=sunshine-builder /sunshine/assets/ /sunshine/assets
 COPY configs/sunshine.conf /sunshine/sunshine.conf
 COPY configs/apps.json /sunshine/apps.json
 COPY startup-gpu.sh /startup.sh
+COPY ensure-nvidia-xorg-driver.sh /ensure-nvidia-xorg-driver.sh
 COPY configs/retroarch.cfg /retroarch.cfg
+COPY configs/xorg-nvidia.conf /usr/share/X11/xorg.conf.d/09-nvidia-custom-location.conf
 
 ENV UNAME retro
 

--- a/startup-gpu.sh
+++ b/startup-gpu.sh
@@ -13,6 +13,12 @@ chown -R ${UNAME}:${UNAME} /sunshine/
 chown -R ${UNAME}:${UNAME} /dev/uinput
 chown -R ${UNAME}:${UNAME} /usr/lib/x86_64-linux-gnu/dri/
 
+# If the host is using the proprietary Nvidia driver, make sure the
+# corresponding xorg driver is installed
+if [ -f /proc/driver/nvidia/version ]; then
+    bash /ensure-nvidia-xorg-driver.sh
+fi
+
 _kill_procs() {
   kill -TERM $sunshine
   wait $sunshine


### PR DESCRIPTION
This is one possible way to do this. What do you think?

If you launch the container in the `nvidia-docker` runtime, the startup process will try to ensure you have an appropriate Xorg driver installed.  It will look for one in `/usr/lib/x86_64-linux-gnu/nvidia/xorg` (which is where the Ubuntu package installs the driver), and it will look in `/nvidia/xorg` (where you can use Docker to map in your host's driver, or another specific version).

If it doesn't find one in one of those locations, it tries to identify an Ubuntu package with the same exact version as the host's driver.  If it can find such a package, it installs it.  If it can't, it prints a failure message.  It will still _attempt_ to launch Xorg in this case, but it warns that it may fail.

If you want to skip all this and just assume that the driver will be there, you can set the environment variable `NVIDIA_SKIP_DRIVER_CHECK` to `1`.